### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup, find_packages  # Always prefer setuptools over distutils
 from codecs import open  # To use a consistent encoding
 from os import path
+from bing import __version__
 
 here = path.abspath(path.dirname(__file__))
 
@@ -14,8 +15,8 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.0',
-
+    version=__version__,
+    py_modules = ['bing'],
     description='Access the Bing Search API',
     #long_description=long_description,
 


### PR DESCRIPTION
Doesn't give ImportError if installed without editable option in pip any more; also get version from module itself.
